### PR TITLE
Fix for new flutter/dart error 105:46: Error: The argument type...

### DIFF
--- a/lib/src/internals/indicator_wrap.dart
+++ b/lib/src/internals/indicator_wrap.dart
@@ -102,7 +102,7 @@ class RefreshWrapperState extends State<RefreshWrapper>
         If this value is 0, no controls will
         cause Flutter to automatically retrieve widget.
      */
-    _sizeController.animateTo(minSpace).then((Null val) {
+    _sizeController.animateTo(minSpace).then((var _) {
       widget.mode = RefreshStatus.idle;
     });
   }


### PR DESCRIPTION
Compiler message:
file:///  <snip>  /.pub-cache/hosted/pub.dartlang.org/pull_to_refresh-1.1.5/lib/src/internals/indicator_wrap.dart:105:46: Error: The argument type
'(dart.core::Null) → dart.core::Null' can't be assigned to the parameter type '(void) → dynamic'.
Try changing the type of the parameter, or casting the argument to '(void) → dynamic'.
    _sizeController.animateTo(minSpace).then((Null val) {