### PR TITLE
Supported the padding property of `BoxScrollView`

### DIFF
--- a/example/lib/ui/example/basic.dart
+++ b/example/lib/ui/example/basic.dart
@@ -76,6 +76,7 @@ class _BasicExampleState extends State<BasicExample>
 
   Widget buildList() {
     return ListView.separated(
+      padding: EdgeInsets.only(left: 5, right: 5),
       itemBuilder: (c, i) => Item(
         title: data1[i],
       ),

--- a/lib/src/smart_refresher.dart
+++ b/lib/src/smart_refresher.dart
@@ -127,7 +127,11 @@ class SmartRefresher extends StatelessWidget {
       if (child is BoxScrollView) {
         //avoid system inject padding when own indicator top or bottom
         Widget sliver = child.buildChildLayout(context);
-        slivers = [sliver];
+        if (child.padding != null) {
+          slivers = [SliverPadding(sliver: sliver, padding: child.padding)];
+        } else {
+          slivers = [sliver];
+        }
       } else {
         slivers = List.from(child.buildSlivers(context), growable: true);
       }


### PR DESCRIPTION
在使用 ListView, GridView, 等继承自 BoxScrollView 的 Widget 时，SmartRefresher 忽略了 padding 属性，导致无法正常显示边距。