### PR TITLE
Avoid touching '_position' when LoadIndicatorState  has been disposed.

### DIFF
--- a/lib/src/internals/indicator_wrap.dart
+++ b/lib/src/internals/indicator_wrap.dart
@@ -370,7 +370,7 @@ abstract class LoadIndicatorState<T extends LoadIndicator> extends State<T>
       }
       _enableLoading = false;
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (_position.outOfRange) {
+        if (mounted && _position?.outOfRange == true) {
           activity.delegate.goBallistic(0);
         }
       });


### PR DESCRIPTION
Fixed peng8350/flutter_pulltorefresh#191