### PR TITLE
fix deprecated function for new Flutter sdk

### DIFF
--- a/lib/src/smart_refresher.dart
+++ b/lib/src/smart_refresher.dart
@@ -270,11 +270,11 @@ class SmartRefresher extends StatefulWidget {
         super(key: key);
 
   static SmartRefresher of(BuildContext context) {
-    return context?.ancestorWidgetOfExactType(SmartRefresher);
+    return context?.findAncestorWidgetOfExactType<SmartRefresher>();
   }
 
   static SmartRefresherState ofState(BuildContext context) {
-    return context?.ancestorStateOfType(TypeMatcher<SmartRefresherState>());
+    return context?.findAncestorStateOfType<SmartRefresherState>();
   }
 
   @override
@@ -1000,7 +1000,7 @@ class RefreshConfiguration extends InheritedWidget {
             RefreshConfiguration.of(context).shouldFooterFollowWhenNotFull;
 
   static RefreshConfiguration of(BuildContext context) {
-    return context.inheritFromWidgetOfExactType(RefreshConfiguration);
+    return context.dependOnInheritedWidgetOfExactType<RefreshConfiguration>();
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.6.3
 homepage: https://github.com/peng8350/flutter_pulltorefresh
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"
   flutter: ">=0.1.4 <2.0.0"
 
 dependencies:


### PR DESCRIPTION
- replace `ancestorWidgetOfExactType` -> `findAncestorWidgetOfExactType`
- replace `ancestorStateOfType` -> `findAncestorStateOfType`
- replace `inheritFromWidgetOfExactType` -> `dependOnInheritedWidgetOfExactType`