### PR TITLE
Migrating example to null safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ simple example,***It must be noted here that ListView must be the child of Smart
         enablePullUp: true,
         header: WaterDropHeader(),
         footer: CustomFooter(
-          builder: (BuildContext context,LoadStatus mode){
+          builder: (BuildContext context,LoadStatus? mode){
             Widget body ;
             if(mode==LoadStatus.idle){
               body =  Text("pull up load");


### PR DESCRIPTION
Adjusted the builder function parameter in the example

![image](https://user-images.githubusercontent.com/35314270/130094445-97dcf26a-4490-441e-8f3f-5d2c92c96a80.png)

