### PR TITLE
fix 'Null check operator used on a null value' for storageContext

### DIFF
--- a/lib/src/internals/refresh_physics.dart
+++ b/lib/src/internals/refresh_physics.dart
@@ -201,17 +201,16 @@ class RefreshPhysics extends ScrollPhysics {
     if (enablePullUp) {
       final RenderSliverLoading? sliverFooter =
           viewportRender!.lastChild as RenderSliverLoading?;
+      BuildContext? context = controller!.position?.context.storageContext;
+      bool enableLoadingWhenNoData = false;
+      bool hideFooterWhenNotFull = false;
+      if(context != null){
+        enableLoadingWhenNoData = RefreshConfiguration.of(context)!.enableLoadingWhenNoData;
+        hideFooterWhenNotFull = RefreshConfiguration.of(context)!.hideFooterWhenNotFull;
+      }
       bottomExtra = (!notFull && sliverFooter!.geometry!.scrollExtent != 0) ||
-              (notFull &&
-                  controller!.footerStatus == LoadStatus.noMore &&
-                  !RefreshConfiguration.of(
-                          controller!.position!.context.storageContext)!
-                      .enableLoadingWhenNoData) ||
-              (notFull &&
-                  (RefreshConfiguration.of(
-                              controller!.position!.context.storageContext)
-                          ?.hideFooterWhenNotFull ??
-                      false))
+              (notFull && controller!.footerStatus == LoadStatus.noMore && !enableLoadingWhenNoData) ||
+              (notFull && (hideFooterWhenNotFull))
           ? 0.0
           : sliverFooter!.layoutExtent;
     }


### PR DESCRIPTION
fix `Null check operator used on a null value`

0 State.context (package:flutter/src/widgets/framework.dart:942)
1 ScrollableState.storageContext (package:flutter/src/widgets/scrollable.dart:645)
2 RefreshPhysics.applyBoundaryConditions (package:pull_to_refresh/src/internals/refresh_physics.dart:212)
3 ScrollPosition.applyBoundaryConditions (package:flutter/src/widgets/scroll_position.dart:481)
4 ScrollPosition.setPixels (package:flutter/src/widgets/scroll_position.dart:265)
5 ScrollPositionWithSingleContext.setPixels (package:flutter/src/widgets/scroll_position_with_single_context.dart:78)
6 BallisticScrollActivity.applyMoveTo (package:flutter/src/widgets/scroll_activity.dart:566)
7 BallisticScrollActivity._tick (package:flutter/src/widgets/scroll_activity.dart:552)
8 AnimationLocalListenersMixin.notifyListeners (package:flutter/src/animation/listener_helpers.dart:161)
9 AnimationController._tick (package:flutter/src/animation/animation_controller.dart:837)
10 Ticker._tick (package:flutter/src/scheduler/ticker.dart:249)
11 SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1175)
...........