### PR TITLE
Update smart_refresher.dart

### DIFF
--- a/lib/src/smart_refresher.dart
+++ b/lib/src/smart_refresher.dart
@@ -344,9 +344,9 @@ class SmartRefresherState extends State<SmartRefresher> {
             dragSpeedRatio: conf?.dragSpeedRatio ?? 1,
             springDescription: conf?.springDescription ??
                 const SpringDescription(
-                  mass: 2.2,
-                  stiffness: 150,
-                  damping: 16,
+                  mass: 1,
+                  stiffness: 364.72,
+                  damping: 35.2,
                 ),
             controller: widget.controller,
             enableScrollWhenTwoLevel: conf?.enableScrollWhenTwoLevel ?? true,


### PR DESCRIPTION
pull to refreshした時にビヨンビヨンなるバグがありました。
原因としては、この[commit](https://github.com/flutter/flutter/commit/cc35800e6a7459d4a067c0478de8a5c657faf299)でSpringDescriptionのロジックが変わったことでした。

こちらを参考に[値を](https://docs.flutter.dev/release/breaking-changes/spring-description-underdamped)修正しました。